### PR TITLE
FIX: ID token claims 변수명 수정(name -> nickname)

### DIFF
--- a/src/main/kotlin/com/ssak3/timeattack/member/auth/oidc/OIDCTokenVerification.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/member/auth/oidc/OIDCTokenVerification.kt
@@ -64,7 +64,7 @@ class OIDCTokenVerification(
                 subject = claims.subject,
                 email = claims["email"] as String,
                 picture = claims["picture"] as String,
-                name = claims["name"] as String
+                name = claims["nickname"] as String
             )
         } catch (e: SignatureException) {
             throw ApplicationException(JWT_INVALID_SIGNATURE, e)

--- a/src/test/kotlin/com/ssak3/timeattack/member/auth/oidc/OIDCTokenVerificationTest.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/member/auth/oidc/OIDCTokenVerificationTest.kt
@@ -35,7 +35,7 @@ class OIDCTokenVerificationTest {
             .setHeaderParam("kid", "test-kid")
             .setHeaderParam("alg", "RS256")
             .claim("email", "test@example.com")
-            .claim("name", "John Doe")
+            .claim("nickname", "John Doe")
             .claim("picture", "https://example.com/picture.jpg")
             .setExpiration(Date(System.currentTimeMillis() + 3600000))
             .signWith(keyPair.private, SignatureAlgorithm.RS256)


### PR DESCRIPTION
#41 

### Proposed Changes
- kakao id token 페이로드의 공식 변수명이 `nickname`인데, `name`으로 조회해서 NPE 발생

### Code Review Point