### PR TITLE
spring scheduler 사용해서 현재 시간에 예약된 푸시 알림 발송

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -19,7 +19,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Cache Gradle dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}

--- a/src/main/kotlin/com/ssak3/timeattack/external/firebase/FirebaseCloudMessageService.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/external/firebase/FirebaseCloudMessageService.kt
@@ -16,7 +16,7 @@ class FirebaseCloudMessageService : Logger {
             Message.builder()
                 .setToken(message.token)
                 .setNotification(
-                    Notification.builder().setTitle(message.title).setBody(message.body).build(),
+                    Notification.builder().setTitle(TITLE).setBody(message.body).build(),
                 )
                 .putData("route", message.route)
                 .build()
@@ -26,5 +26,9 @@ class FirebaseCloudMessageService : Logger {
         logger.info("[Firebase Messaging] send successfully: $response")
 
         return response
+    }
+
+    companion object {
+        const val TITLE = "SPURT"
     }
 }

--- a/src/main/kotlin/com/ssak3/timeattack/external/firebase/FirebaseCloudMessageService.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/external/firebase/FirebaseCloudMessageService.kt
@@ -18,7 +18,12 @@ class FirebaseCloudMessageService : Logger {
                 .setNotification(
                     Notification.builder().setTitle(TITLE).setBody(message.body).build(),
                 )
-                .putData("route", message.route)
+                .putAllData(
+                    mapOf(
+                        "route" to message.route,
+                        "taskId" to message.taskId.toString(),
+                    ),
+                )
                 .build()
 
         val response = firebaseMessaging.send(fcmMessage)

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/controller/PushNotificationController.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/controller/PushNotificationController.kt
@@ -29,7 +29,6 @@ class PushNotificationController(
                 FcmMessage(
                     token = request.token,
                     platform = DevicePlatform.valueOf(request.platform),
-                    title = request.title,
                     body = request.body,
                     route = request.route,
                 ),

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/controller/PushNotificationController.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/controller/PushNotificationController.kt
@@ -29,6 +29,7 @@ class PushNotificationController(
                 FcmMessage(
                     token = request.token,
                     platform = DevicePlatform.valueOf(request.platform),
+                    taskId = request.taskId.toLong(),
                     body = request.body,
                     route = request.route,
                 ),

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/controller/dto/PushNotificationSendRequest.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/controller/dto/PushNotificationSendRequest.kt
@@ -3,7 +3,7 @@ package com.ssak3.timeattack.notifications.controller.dto
 data class PushNotificationSendRequest(
     val token: String,
     val platform: String,
-    val title: String,
+    val taskId: String,
     val body: String,
     val route: String,
 )

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmDevice.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmDevice.kt
@@ -17,4 +17,14 @@ class FcmDevice(
             devicePlatform = devicePlatform,
             status = status,
         )
+
+    companion object {
+        fun fromEntity(entity: FcmDeviceEntity) =
+            FcmDevice(
+                member = Member.fromEntity(entity.member),
+                fcmRegistrationToken = entity.fcmRegistrationToken,
+                devicePlatform = entity.devicePlatform,
+                status = entity.status,
+            )
+    }
 }

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmMessage.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmMessage.kt
@@ -5,6 +5,7 @@ import com.ssak3.timeattack.external.firebase.domain.DevicePlatform
 data class FcmMessage(
     val token: String,
     val platform: DevicePlatform,
+    val taskId: Long,
     val body: String,
     val route: String,
 )

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmMessage.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmMessage.kt
@@ -5,7 +5,6 @@ import com.ssak3.timeattack.external.firebase.domain.DevicePlatform
 data class FcmMessage(
     val token: String,
     val platform: DevicePlatform,
-    val title: String,
     val body: String,
     val route: String,
 )

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmNotificationConstants.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmNotificationConstants.kt
@@ -1,4 +1,4 @@
-package com.ssak3.timeattack.notifications.utils
+package com.ssak3.timeattack.notifications.domain
 
 import kotlin.random.Random
 

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/domain/PushNotification.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/domain/PushNotification.kt
@@ -20,4 +20,14 @@ data class PushNotification(
             isDeleted = isDeleted,
             order = order,
         )
+
+    companion object {
+        fun fromEntity(entity: PushNotificationEntity) =
+            PushNotification(
+                member = Member.fromEntity(entity.member),
+                task = Task.fromEntity(entity.task),
+                scheduledAt = entity.scheduledAt,
+                order = entity.order,
+            )
+    }
 }

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/domain/PushNotification.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/domain/PushNotification.kt
@@ -5,7 +5,7 @@ import com.ssak3.timeattack.notifications.repository.entity.PushNotificationEnti
 import com.ssak3.timeattack.task.domain.Task
 import java.time.LocalDateTime
 
-data class PushNotification(
+class PushNotification(
     val member: Member,
     val task: Task,
     val scheduledAt: LocalDateTime,

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepository.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepository.kt
@@ -3,4 +3,4 @@ package com.ssak3.timeattack.notifications.repository
 import com.ssak3.timeattack.notifications.repository.entity.FcmDeviceEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface FcmDeviceRepository : JpaRepository<FcmDeviceEntity, Long>
+interface FcmDeviceRepository : JpaRepository<FcmDeviceEntity, Long>, FcmDeviceRepositoryCustom

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustom.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustom.kt
@@ -1,0 +1,8 @@
+package com.ssak3.timeattack.notifications.repository
+
+import com.ssak3.timeattack.member.repository.entity.MemberEntity
+import com.ssak3.timeattack.notifications.repository.entity.FcmDeviceEntity
+
+interface FcmDeviceRepositoryCustom {
+    fun findActiveByMember(member: MemberEntity): List<FcmDeviceEntity>
+}

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustom.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustom.kt
@@ -1,8 +1,7 @@
 package com.ssak3.timeattack.notifications.repository
 
-import com.ssak3.timeattack.member.repository.entity.MemberEntity
 import com.ssak3.timeattack.notifications.repository.entity.FcmDeviceEntity
 
 interface FcmDeviceRepositoryCustom {
-    fun findActiveByMember(member: MemberEntity): List<FcmDeviceEntity>
+    fun findActiveByMember(memberId: Long): List<FcmDeviceEntity>
 }

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustomImpl.kt
@@ -1,0 +1,22 @@
+package com.ssak3.timeattack.notifications.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ssak3.timeattack.member.repository.entity.MemberEntity
+import com.ssak3.timeattack.notifications.repository.entity.FcmDeviceEntity
+import com.ssak3.timeattack.notifications.repository.entity.QFcmDeviceEntity
+import org.springframework.stereotype.Repository
+
+@Repository
+class FcmDeviceRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory,
+) : FcmDeviceRepositoryCustom {
+    private val fcmDevice = QFcmDeviceEntity.fcmDeviceEntity
+
+    override fun findActiveByMember(member: MemberEntity): List<FcmDeviceEntity> {
+        return queryFactory.selectFrom(fcmDevice)
+            .where(
+                fcmDevice.member.id.eq(member.id),
+                fcmDevice.status.isTrue,
+            ).fetch()
+    }
+}

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustomImpl.kt
@@ -1,7 +1,6 @@
 package com.ssak3.timeattack.notifications.repository
 
 import com.querydsl.jpa.impl.JPAQueryFactory
-import com.ssak3.timeattack.member.repository.entity.MemberEntity
 import com.ssak3.timeattack.notifications.repository.entity.FcmDeviceEntity
 import com.ssak3.timeattack.notifications.repository.entity.QFcmDeviceEntity
 import org.springframework.stereotype.Repository
@@ -12,10 +11,10 @@ class FcmDeviceRepositoryCustomImpl(
 ) : FcmDeviceRepositoryCustom {
     private val fcmDevice = QFcmDeviceEntity.fcmDeviceEntity
 
-    override fun findActiveByMember(member: MemberEntity): List<FcmDeviceEntity> {
+    override fun findActiveByMember(memberId: Long): List<FcmDeviceEntity> {
         return queryFactory.selectFrom(fcmDevice)
             .where(
-                fcmDevice.member.id.eq(member.id),
+                fcmDevice.member.id.eq(memberId),
                 fcmDevice.status.isTrue,
             ).fetch()
     }

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/repository/PushNotificationRepository.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/repository/PushNotificationRepository.kt
@@ -3,4 +3,4 @@ package com.ssak3.timeattack.notifications.repository
 import com.ssak3.timeattack.notifications.repository.entity.PushNotificationEntity
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface PushNotificationRepository : JpaRepository<PushNotificationEntity, Long>
+interface PushNotificationRepository : JpaRepository<PushNotificationEntity, Long>, PushNotificationRepositoryCustom

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/repository/PushNotificationRepositoryCustom.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/repository/PushNotificationRepositoryCustom.kt
@@ -1,0 +1,8 @@
+package com.ssak3.timeattack.notifications.repository
+
+import com.ssak3.timeattack.notifications.repository.entity.PushNotificationEntity
+import java.time.LocalDateTime
+
+interface PushNotificationRepositoryCustom {
+    fun findActiveAndScheduledAt(datetime: LocalDateTime): List<PushNotificationEntity>
+}

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/repository/PushNotificationRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/repository/PushNotificationRepositoryCustomImpl.kt
@@ -1,0 +1,22 @@
+package com.ssak3.timeattack.notifications.repository
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.ssak3.timeattack.notifications.repository.entity.PushNotificationEntity
+import com.ssak3.timeattack.notifications.repository.entity.QPushNotificationEntity
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+class PushNotificationRepositoryCustomImpl(
+    private val queryFactory: JPAQueryFactory,
+) : PushNotificationRepositoryCustom {
+    private val pushNotification = QPushNotificationEntity.pushNotificationEntity
+
+    override fun findActiveAndScheduledAt(datetime: LocalDateTime): List<PushNotificationEntity> {
+        return queryFactory.selectFrom(pushNotification)
+            .where(
+                pushNotification.scheduledAt.eq(datetime),
+                pushNotification.isDeleted.isFalse,
+            ).fetch()
+    }
+}

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/service/FcmDeviceService.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/service/FcmDeviceService.kt
@@ -1,6 +1,5 @@
 package com.ssak3.timeattack.notifications.service
 
-import com.ssak3.timeattack.member.domain.Member
 import com.ssak3.timeattack.notifications.domain.FcmDevice
 import com.ssak3.timeattack.notifications.repository.FcmDeviceRepository
 import org.springframework.stereotype.Service
@@ -15,6 +14,6 @@ class FcmDeviceService(
         fcmDeviceRepository.save(fcmDevice.toEntity())
     }
 
-    fun getDevicesByMember(member: Member): List<FcmDevice> =
-        fcmDeviceRepository.findActiveByMember(member.toEntity()).map(FcmDevice::fromEntity)
+    fun getDevicesByMember(memberId: Long): List<FcmDevice> =
+        fcmDeviceRepository.findActiveByMember(memberId).map(FcmDevice::fromEntity)
 }

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/service/FcmDeviceService.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/service/FcmDeviceService.kt
@@ -1,5 +1,6 @@
 package com.ssak3.timeattack.notifications.service
 
+import com.ssak3.timeattack.member.domain.Member
 import com.ssak3.timeattack.notifications.domain.FcmDevice
 import com.ssak3.timeattack.notifications.repository.FcmDeviceRepository
 import org.springframework.stereotype.Service
@@ -13,4 +14,7 @@ class FcmDeviceService(
     fun save(fcmDevice: FcmDevice) {
         fcmDeviceRepository.save(fcmDevice.toEntity())
     }
+
+    fun getDevicesByMember(member: Member): List<FcmDevice> =
+        fcmDeviceRepository.findActiveByMember(member.toEntity()).map(FcmDevice::fromEntity)
 }

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationListener.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationListener.kt
@@ -32,7 +32,7 @@ class PushNotificationListener(
             PushNotification(
                 member = member,
                 task = task,
-                scheduledAt = event.alarmTime,
+                scheduledAt = event.alarmTime.withSecond(0),
                 order = 0,
             )
 
@@ -49,7 +49,7 @@ class PushNotificationListener(
                 PushNotification(
                     member = member,
                     task = task,
-                    scheduledAt = it.alarmTime,
+                    scheduledAt = it.alarmTime.withSecond(0),
                     order = it.order,
                 )
             }

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationScheduler.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationScheduler.kt
@@ -2,8 +2,8 @@ package com.ssak3.timeattack.notifications.service
 
 import com.ssak3.timeattack.external.firebase.domain.DevicePlatform
 import com.ssak3.timeattack.notifications.domain.FcmMessage
-import com.ssak3.timeattack.notifications.utils.FcmNotificationConstants.getMessage
-import com.ssak3.timeattack.notifications.utils.FcmNotificationConstants.getRoute
+import com.ssak3.timeattack.notifications.domain.FcmNotificationConstants.getMessage
+import com.ssak3.timeattack.notifications.domain.FcmNotificationConstants.getRoute
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.EnableScheduling
@@ -21,9 +21,10 @@ class PushNotificationScheduler(
     @Async
     @Scheduled(cron = "0 * * * * *") // 1분 단위
     fun sendNotifications() {
-        val currentScheduledNotifications = pushNotificationService.getCurrentList()
-        currentScheduledNotifications.map {
-            fcmDeviceService.getDevicesByMember(it.member).forEach { device ->
+        val currentScheduledNotifications = pushNotificationService.getNotificationsByCurrentTime()
+        currentScheduledNotifications.forEach {
+            checkNotNull(it.member.id)
+            fcmDeviceService.getDevicesByMember(it.member.id).forEach { device ->
                 val message =
                     FcmMessage(
                         token = device.fcmRegistrationToken,

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationScheduler.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationScheduler.kt
@@ -19,7 +19,7 @@ class PushNotificationScheduler(
     private val fcmPushNotificationService: FcmPushNotificationService,
 ) {
     @Async
-    @Scheduled(cron = "0 * * * * *") // 1분 단위
+    @Scheduled(cron = "0 0/5 * * * ?") //5분 단위
     fun sendNotifications() {
         val currentScheduledNotifications = pushNotificationService.getNotificationsByCurrentTime()
         currentScheduledNotifications.forEach {

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationScheduler.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationScheduler.kt
@@ -19,7 +19,7 @@ class PushNotificationScheduler(
     private val fcmPushNotificationService: FcmPushNotificationService,
 ) {
     @Async
-    @Scheduled(cron = "0 0/5 * * * ?") //5분 단위
+    @Scheduled(cron = "0 0/5 * * * ?") // 5분 단위
     fun sendNotifications() {
         val currentScheduledNotifications = pushNotificationService.getNotificationsByCurrentTime()
         currentScheduledNotifications.forEach {

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationScheduler.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationScheduler.kt
@@ -24,11 +24,13 @@ class PushNotificationScheduler(
         val currentScheduledNotifications = pushNotificationService.getNotificationsByCurrentTime()
         currentScheduledNotifications.forEach {
             checkNotNull(it.member.id)
+            checkNotNull(it.task.id)
             fcmDeviceService.getDevicesByMember(it.member.id).forEach { device ->
                 val message =
                     FcmMessage(
                         token = device.fcmRegistrationToken,
                         platform = DevicePlatform.valueOf(device.devicePlatform.toString()),
+                        taskId = it.task.id,
                         body = getMessage(it.order),
                         route = getRoute(it.order),
                     )

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationService.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationService.kt
@@ -19,7 +19,7 @@ class PushNotificationService(
         pushNotificationRepository.saveAll(entities)
     }
 
-    fun getCurrentList(): List<PushNotification> {
+    fun getNotificationsByCurrentTime(): List<PushNotification> {
         return pushNotificationRepository.findActiveAndScheduledAt(
             datetime = LocalDateTime.now().withSecond(0).withNano(0),
         ).map(PushNotification::fromEntity)

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationService.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationService.kt
@@ -4,6 +4,7 @@ import com.ssak3.timeattack.notifications.domain.PushNotification
 import com.ssak3.timeattack.notifications.repository.PushNotificationRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 @Service
 class PushNotificationService(
@@ -16,5 +17,11 @@ class PushNotificationService(
     fun saveAll(pushNotifications: List<PushNotification>) {
         val entities = pushNotifications.map { it.toEntity() }
         pushNotificationRepository.saveAll(entities)
+    }
+
+    fun getCurrentList(): List<PushNotification> {
+        return pushNotificationRepository.findActiveAndScheduledAt(
+            datetime = LocalDateTime.now().withSecond(0).withNano(0),
+        ).map(PushNotification::fromEntity)
     }
 }

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/utils/FcmNotificationConstants.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/utils/FcmNotificationConstants.kt
@@ -2,11 +2,19 @@ package com.ssak3.timeattack.notifications.utils
 
 import kotlin.random.Random
 
-object PushNotificationMessages {
+object FcmNotificationConstants {
     fun getMessage(order: Int): String {
         val messages = messageTemplate[order] ?: throw IllegalStateException("message not exist for this number")
         val index = Random.nextInt(messages.size)
         return messages[index]
+    }
+
+    fun getRoute(order: Int): String {
+        return if (order == 0) {
+            "/action/push"
+        } else {
+            "/action/push?left=${REMINDER_LIMIT-order}"
+        }
     }
 
     private val messageTemplate =
@@ -40,4 +48,6 @@ object PushNotificationMessages {
                     """.trimIndent(),
                 ),
         )
+
+    private const val REMINDER_LIMIT = 3
 }

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/utils/FcmNotificationConstants.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/utils/FcmNotificationConstants.kt
@@ -13,7 +13,7 @@ object FcmNotificationConstants {
         return if (order == 0) {
             "/action/push"
         } else {
-            "/action/push?left=${REMINDER_LIMIT-order}"
+            "/action/push?left=${REMINDER_LIMIT - order}"
         }
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -27,6 +27,8 @@ jwt:
   refresh-token-validity-in-seconds: ${DEV_JWT_REFRESH_TOKEN_VALIDITY}
 fcm:
   secret-key: ${FIREBASE_SECRET_KEY}
+  scheduler:
+    status: ${FCM_SEND_SCHEDULER_STATUS:false}
 cors:
   allowed-origins:
     - ${DEV_CORS_ALLOWED_ORIGINS_01}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -35,6 +35,8 @@ kakao:
   redirect-uri: ${DEV_KAKAO_REDIRECT_URI}
 fcm:
   secret-key: ${FIREBASE_SECRET_KEY}
+  scheduler:
+    status: false
 cors:
   allowed-origins:
     - ${DEV_CORS_ALLOWED_ORIGINS_01}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,8 @@ jwt:
   refresh-token-validity-in-seconds: ${JWT_REFRESH_TOKEN_VALIDITY}
 fcm:
   secret-key: ${FIREBASE_SECRET_KEY}
+  scheduler:
+    status: false
 cors:
   allowed-origins:
     - ${CORS_ALLOWED_ORIGINS_01}
@@ -44,7 +46,6 @@ security:
     - ${SECURITY_PERMIT_URLS_02}
     - ${SECURITY_PERMIT_URLS_03}
     - ${SECURITY_PERMIT_URLS_04}
-
 springdoc:
   swagger-ui:
     path: ${SPRINGDOC_SWAGGER_UI_PATH}

--- a/src/test/kotlin/com/ssak3/timeattack/fixture/Fixture.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/fixture/Fixture.kt
@@ -146,7 +146,6 @@ object Fixture {
         task = task,
         scheduledAt = scheduledAt,
         isDeleted = isDeleted,
-        order = order
-
+        order = order,
     )
 }

--- a/src/test/kotlin/com/ssak3/timeattack/fixture/Fixture.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/fixture/Fixture.kt
@@ -3,6 +3,7 @@ package com.ssak3.timeattack.fixture
 import com.ssak3.timeattack.member.domain.Member
 import com.ssak3.timeattack.member.domain.OAuthProvider
 import com.ssak3.timeattack.member.repository.entity.OAuthProviderInfo
+import com.ssak3.timeattack.notifications.domain.PushNotification
 import com.ssak3.timeattack.persona.domain.Persona
 import com.ssak3.timeattack.persona.domain.TaskKeywordsCombination
 import com.ssak3.timeattack.task.domain.Task
@@ -132,5 +133,20 @@ object Fixture {
         createdAt = createdAt,
         updatedAt = updatedAt,
         isDeleted = isDeleted,
+    )
+
+    fun createPushNotification(
+        member: Member = createMember(),
+        task: Task = createTask(),
+        scheduledAt: LocalDateTime = LocalDateTime.now(),
+        isDeleted: Boolean = false,
+        order: Int = 0,
+    ) = PushNotification(
+        member = member,
+        task = task,
+        scheduledAt = scheduledAt,
+        isDeleted = isDeleted,
+        order = order
+
     )
 }

--- a/src/test/kotlin/com/ssak3/timeattack/notifications/PushNotificationRepositoryTest.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/notifications/PushNotificationRepositoryTest.kt
@@ -2,7 +2,6 @@ package com.ssak3.timeattack.notifications
 
 import com.ssak3.timeattack.common.config.QueryDslConfig
 import com.ssak3.timeattack.fixture.Fixture
-import com.ssak3.timeattack.member.repository.MemberRepository
 import com.ssak3.timeattack.notifications.repository.PushNotificationRepository
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -20,15 +19,14 @@ import kotlin.test.assertEquals
 class PushNotificationRepositoryTest(
     @Autowired private val pushNotificationRepository: PushNotificationRepository,
 ) {
-
     @BeforeEach
     fun set() {
         (0..3).forEach {
             pushNotificationRepository.save(
                 Fixture.createPushNotification(
                     scheduledAt = LocalDateTime.now().plusMinutes(it.toLong()).withSecond(0).withNano(0),
-                    order = it
-                ).toEntity()
+                    order = it,
+                ).toEntity(),
             )
         }
     }
@@ -37,9 +35,10 @@ class PushNotificationRepositoryTest(
     @DisplayName("현재 시간에 스케줄링된 데이터 반환")
     fun test_findActiveAndScheduledAt() {
         val now = LocalDateTime.now().withSecond(0).withNano(0)
-        val notifications = pushNotificationRepository.findActiveAndScheduledAt(
-            datetime = now,
-        )
+        val notifications =
+            pushNotificationRepository.findActiveAndScheduledAt(
+                datetime = now,
+            )
 
         assertEquals(1, notifications.size)
         assertEquals(0, notifications.get(0).order)

--- a/src/test/kotlin/com/ssak3/timeattack/notifications/PushNotificationRepositoryTest.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/notifications/PushNotificationRepositoryTest.kt
@@ -1,0 +1,47 @@
+package com.ssak3.timeattack.notifications
+
+import com.ssak3.timeattack.common.config.QueryDslConfig
+import com.ssak3.timeattack.fixture.Fixture
+import com.ssak3.timeattack.member.repository.MemberRepository
+import com.ssak3.timeattack.notifications.repository.PushNotificationRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import java.time.LocalDateTime
+import kotlin.test.assertEquals
+
+@DataJpaTest
+@Import(QueryDslConfig::class)
+@ActiveProfiles("test")
+class PushNotificationRepositoryTest(
+    @Autowired private val pushNotificationRepository: PushNotificationRepository,
+) {
+
+    @BeforeEach
+    fun set() {
+        (0..3).forEach {
+            pushNotificationRepository.save(
+                Fixture.createPushNotification(
+                    scheduledAt = LocalDateTime.now().plusMinutes(it.toLong()).withSecond(0).withNano(0),
+                    order = it
+                ).toEntity()
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("현재 시간에 스케줄링된 데이터 반환")
+    fun test_findActiveAndScheduledAt() {
+        val now = LocalDateTime.now().withSecond(0).withNano(0)
+        val notifications = pushNotificationRepository.findActiveAndScheduledAt(
+            datetime = now,
+        )
+
+        assertEquals(1, notifications.size)
+        assertEquals(0, notifications.get(0).order)
+    }
+}


### PR DESCRIPTION
#55 

### Proposed Changes
* push_notification에서 현재 시간에 예약된 알림 정보를 호출합니다.
* fcm_deivce에서 사용자의 디바이스 정보를 호출합니다.
* 1분마다 현재 시간에 맞는 푸시 알림을 발송합니다.

### Code Review Point
scheduler가 1분마다 도는거라 지금 상황에서 리소스 낭비일까봐 비활성화해놨는데 다들 어떻게 생각하는지 궁금해용 
