### PR TITLE
로그인 응답에 멤버 정보 추가

### DIFF
--- a/src/main/kotlin/com/ssak3/timeattack/member/controller/AuthController.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/member/controller/AuthController.kt
@@ -2,6 +2,9 @@ package com.ssak3.timeattack.member.controller
 
 import com.ssak3.timeattack.common.security.JwtTokenDto
 import com.ssak3.timeattack.common.security.refreshtoken.RefreshTokenService
+import com.ssak3.timeattack.member.controller.dto.LoginRequest
+import com.ssak3.timeattack.member.controller.dto.LoginResponse
+import com.ssak3.timeattack.member.controller.dto.RefreshRequest
 import com.ssak3.timeattack.member.domain.Member
 import com.ssak3.timeattack.member.service.AuthService
 import io.swagger.v3.oas.annotations.Operation
@@ -28,9 +31,9 @@ class AuthController(
         response: HttpServletResponse,
     ): ResponseEntity<LoginResponse> {
         // 소셜 로그인 후, JWT 토큰 반환
-        val (tokens, isNewUser) = authService.authenticateAndRegister(loginRequest)
+        val loginResult = authService.authenticateAndRegister(loginRequest)
 
-        return ResponseEntity.ok(LoginResponse(tokens, isNewUser))
+        return ResponseEntity.ok(LoginResponse(loginResult.jwtTokenDto, loginResult.isNewUser, loginResult.memberInfo))
     }
 
     @Operation(summary = "인증 필터 테스트", security = [SecurityRequirement(name = "BearerAuth")])

--- a/src/main/kotlin/com/ssak3/timeattack/member/controller/dto/LoginRequest.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/member/controller/dto/LoginRequest.kt
@@ -1,4 +1,4 @@
-package com.ssak3.timeattack.member.controller
+package com.ssak3.timeattack.member.controller.dto
 
 import com.ssak3.timeattack.common.domain.DevicePlatform
 import com.ssak3.timeattack.member.domain.OAuthProvider

--- a/src/main/kotlin/com/ssak3/timeattack/member/controller/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/member/controller/dto/LoginResponse.kt
@@ -1,8 +1,10 @@
-package com.ssak3.timeattack.member.controller
+package com.ssak3.timeattack.member.controller.dto
 
 import com.ssak3.timeattack.common.security.JwtTokenDto
+import com.ssak3.timeattack.member.service.dto.MemberInfo
 
 data class LoginResponse(
     val jwtTokenDto: JwtTokenDto,
     val isNewUser: Boolean,
+    val memberInfo: MemberInfo,
 )

--- a/src/main/kotlin/com/ssak3/timeattack/member/controller/dto/RefreshRequest.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/member/controller/dto/RefreshRequest.kt
@@ -1,4 +1,4 @@
-package com.ssak3.timeattack.member.controller
+package com.ssak3.timeattack.member.controller.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode

--- a/src/main/kotlin/com/ssak3/timeattack/member/service/AuthService.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/member/service/AuthService.kt
@@ -2,6 +2,7 @@ package com.ssak3.timeattack.member.service
 
 import com.ssak3.timeattack.common.security.JwtTokenProvider
 import com.ssak3.timeattack.common.security.refreshtoken.RefreshTokenService
+import com.ssak3.timeattack.common.utils.Logger
 import com.ssak3.timeattack.member.auth.client.OAuthClientFactory
 import com.ssak3.timeattack.member.auth.oidc.OIDCPayload
 import com.ssak3.timeattack.member.auth.oidc.OIDCTokenVerification
@@ -24,7 +25,7 @@ class AuthService(
     private val jwtTokenProvider: JwtTokenProvider,
     private val refreshTokenService: RefreshTokenService,
     private val eventPublisher: ApplicationEventPublisher,
-) {
+) : Logger {
     fun authenticateAndRegister(request: LoginRequest): LoginResult {
         // id token 요청
         val oAuthClient = oAuthClientFactory.getClient(request.provider)
@@ -56,11 +57,14 @@ class AuthService(
         // 기기 정보 저장 이벤트 발행
         eventPublisher.publishEvent(DeviceRegisterEvent(member.id, request.deviceId, request.deviceType))
 
-        return LoginResult(
-            tokens,
-            isNewUser,
-            MemberInfo(member.id, member.nickname, member.email, member.profileImageUrl),
-        )
+        val loginResult =
+            LoginResult(
+                tokens,
+                isNewUser,
+                MemberInfo(member.id, member.nickname, member.email, member.profileImageUrl),
+            )
+        logger.info("loginResult = $loginResult")
+        return loginResult
     }
 
     private fun createMember(

--- a/src/main/kotlin/com/ssak3/timeattack/member/service/dto/LoginResult.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/member/service/dto/LoginResult.kt
@@ -1,0 +1,19 @@
+package com.ssak3.timeattack.member.service.dto
+
+import com.ssak3.timeattack.common.security.JwtTokenDto
+
+/**
+ * AuthService의 authenticateAndRegister() 메서드의 반환값
+ */
+data class LoginResult(
+    val jwtTokenDto: JwtTokenDto,
+    val isNewUser: Boolean,
+    val memberInfo: MemberInfo,
+)
+
+data class MemberInfo(
+    val memberId: Long,
+    val nickname: String,
+    val email: String,
+    val profileImageUrl: String?,
+)


### PR DESCRIPTION
#117 

### Proposed Changes
- 프론트에서 멤버 정보 관리하기 위해서 로그인 응답에 멤버 정보 추가

### Code Review Point
- 서비스 -> 컨트롤러로 전달하는 dto명 적절한지