### PR TITLE
마감일 지난 작업 FAIL 처리 스케줄러 

### DIFF
--- a/src/main/kotlin/com/ssak3/timeattack/common/config/SchedulerConfig.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/common/config/SchedulerConfig.kt
@@ -1,0 +1,18 @@
+package com.ssak3.timeattack.common.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+
+@Configuration
+class SchedulerConfig {
+    @Bean
+    fun taskScheduler(): TaskScheduler {
+        val taskScheduler = ThreadPoolTaskScheduler()
+        taskScheduler.poolSize = 3
+        taskScheduler.setThreadNamePrefix("task-scheduler-")
+        taskScheduler.initialize()
+        return taskScheduler
+    }
+}

--- a/src/main/kotlin/com/ssak3/timeattack/task/domain/TaskStatus.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/domain/TaskStatus.kt
@@ -24,4 +24,14 @@ enum class TaskStatus {
             COMPLETE, FAIL -> false
         }
     }
+
+    companion object {
+        val statusesToFail =
+            listOf(
+                BEFORE,
+                PROCRASTINATING,
+                HOLDING_OFF,
+                WARMING_UP,
+            )
+    }
 }

--- a/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustom.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustom.kt
@@ -1,5 +1,6 @@
 package com.ssak3.timeattack.task.repository
 
+import com.ssak3.timeattack.task.domain.TaskStatus
 import com.ssak3.timeattack.task.repository.entity.TaskEntity
 import java.time.LocalDateTime
 
@@ -35,4 +36,11 @@ interface TaskRepositoryCustom {
      * 전체 할일 조회
      */
     fun findAllTodos(id: Long): List<TaskEntity>
+
+    /**
+     * Fail 처리할 가능성 있는 작업들만 조회
+     * - 아직 마감 시간 안지났고, 현재 상태가 BEFORE, PROCRASTINATING, HOLDING_OFF, WARMING_UP인 작업들 조회
+     * - 애플리케이션 완전 시작된 후 조회된 작업들을 모두 스케줄러에 등록하기 위한 쿼리
+     */
+    fun findTasksToFail(statusesToFail: List<TaskStatus>): List<TaskEntity>
 }

--- a/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustom.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustom.kt
@@ -42,7 +42,7 @@ interface TaskRepositoryCustom {
      * - 아직 마감 시간 안지났고, 현재 상태가 BEFORE, PROCRASTINATING, HOLDING_OFF, WARMING_UP인 작업들 조회
      * - 애플리케이션 완전 시작된 후 조회된 작업들을 모두 스케줄러에 등록하기 위한 쿼리
      */
-    fun findTodoTasks(statusesToFail: List<TaskStatus>): List<TaskEntity>
+    fun findTodoTasks(todoStatuses: List<TaskStatus>): List<TaskEntity>
 
     /*
      * 현재 활성화된(몰입중인) 작업 목록 조회

--- a/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustom.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustom.kt
@@ -38,11 +38,11 @@ interface TaskRepositoryCustom {
     fun findAllTodos(id: Long): List<TaskEntity>
 
     /**
-     * Fail 처리할 가능성 있는 작업들만 조회
+     * 현재 시점에서 해야 할 일 조회(=Fail 처리할 가능성 있는 작업들만 조회)
      * - 아직 마감 시간 안지났고, 현재 상태가 BEFORE, PROCRASTINATING, HOLDING_OFF, WARMING_UP인 작업들 조회
      * - 애플리케이션 완전 시작된 후 조회된 작업들을 모두 스케줄러에 등록하기 위한 쿼리
      */
-    fun findTasksToFail(statusesToFail: List<TaskStatus>): List<TaskEntity>
+    fun findTodoTasks(statusesToFail: List<TaskStatus>): List<TaskEntity>
 
     /*
      * 현재 활성화된(몰입중인) 작업 목록 조회

--- a/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustomImpl.kt
@@ -80,14 +80,14 @@ class TaskRepositoryCustomImpl(
             .fetch()
     }
 
-    override fun findTodoTasks(statusesToFail: List<TaskStatus>): List<TaskEntity> {
+    override fun findTodoTasks(todoStatuses: List<TaskStatus>): List<TaskEntity> {
         val now = LocalDateTime.now()
 
         return queryFactory
             .select(qTask)
             .from(qTask)
             .where(
-                qTask.status.`in`(statusesToFail)
+                qTask.status.`in`(todoStatuses)
                     .and(qTask.dueDatetime.after(now))
                     .and(qTask.isDeleted.isFalse),
             )

--- a/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustomImpl.kt
@@ -80,7 +80,7 @@ class TaskRepositoryCustomImpl(
             .fetch()
     }
 
-    override fun findTasksToFail(statusesToFail: List<TaskStatus>): List<TaskEntity> {
+    override fun findTodoTasks(statusesToFail: List<TaskStatus>): List<TaskEntity> {
         val now = LocalDateTime.now()
 
         return queryFactory

--- a/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/repository/TaskRepositoryCustomImpl.kt
@@ -80,6 +80,20 @@ class TaskRepositoryCustomImpl(
             .fetch()
     }
 
+    override fun findTasksToFail(statusesToFail: List<TaskStatus>): List<TaskEntity> {
+        val now = LocalDateTime.now()
+
+        return queryFactory
+            .select(qTask)
+            .from(qTask)
+            .where(
+                qTask.status.`in`(statusesToFail)
+                    .and(qTask.dueDatetime.after(now))
+                    .and(qTask.isDeleted.isFalse),
+            )
+            .fetch()
+    }
+
     override fun findAbandonedOrIgnoredTasks(memberId: Long): TaskEntity? {
         val now = LocalDateTime.now()
         val threeMinutesAgo = now.minusMinutes(3)

--- a/src/main/kotlin/com/ssak3/timeattack/task/scheduler/OverdueTaskFailureScheduler.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/scheduler/OverdueTaskFailureScheduler.kt
@@ -41,6 +41,7 @@ class OverdueTaskFailureScheduler(
                     )
 
             if (task.status in statusesToFail) {
+                logger.info("현재 상태가 ${task.status}인 Task(${task.id})는 마감 시간이 지나 Fail 처리 됩니다.")
                 task.status = TaskStatus.FAIL
                 taskRepository.save(task.toEntity())
             }

--- a/src/main/kotlin/com/ssak3/timeattack/task/scheduler/OverdueTaskFailureScheduler.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/scheduler/OverdueTaskFailureScheduler.kt
@@ -1,0 +1,59 @@
+package com.ssak3.timeattack.task.scheduler
+
+import com.ssak3.timeattack.common.exception.ApplicationException
+import com.ssak3.timeattack.common.exception.ApplicationExceptionType
+import com.ssak3.timeattack.common.utils.Logger
+import com.ssak3.timeattack.common.utils.checkNotNull
+import com.ssak3.timeattack.task.domain.Task
+import com.ssak3.timeattack.task.domain.TaskStatus
+import com.ssak3.timeattack.task.repository.TaskRepository
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.stereotype.Service
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.ZoneId
+
+@Service
+class OverdueTaskFailureScheduler(
+    private val taskRepository: TaskRepository,
+    private val taskScheduler: TaskScheduler,
+    private val transactionTemplate: TransactionTemplate,
+) : Logger {
+    fun scheduleTaskTimeoutFailure(task: Task) {
+        checkNotNull(task.id, "taskId")
+        taskScheduler.schedule(
+            { checkAndUpdateTaskStatus(task.id) },
+            task.dueDatetime.plusMinutes(1).atZone(ZoneId.systemDefault()).toInstant(),
+        )
+    }
+
+    /**
+     * task 상태가 BEFORE, PROCRASTINATING, HOLDING_OFF, WARMING_UP 이라면 Fail 처리
+     */
+    private fun checkAndUpdateTaskStatus(taskId: Long) {
+        logger.info("Task 마감 체크 스케줄러 스레드 동작 시작! ${Thread.currentThread().name}")
+        transactionTemplate.execute {
+            val task =
+                taskRepository.findByIdAndIsDeletedIsFalse(taskId)
+                    ?.let { Task.fromEntity(it) }
+                    ?: throw ApplicationException(
+                        ApplicationExceptionType.TASK_NOT_FOUND_BY_ID,
+                        taskId,
+                    )
+
+            if (task.status in statusesToFail) {
+                task.status = TaskStatus.FAIL
+                taskRepository.save(task.toEntity())
+            }
+        }
+    }
+
+    companion object {
+        val statusesToFail =
+            listOf(
+                TaskStatus.BEFORE,
+                TaskStatus.PROCRASTINATING,
+                TaskStatus.HOLDING_OFF,
+                TaskStatus.WARMING_UP,
+            )
+    }
+}

--- a/src/main/kotlin/com/ssak3/timeattack/task/scheduler/OverdueTaskFailureScheduler.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/scheduler/OverdueTaskFailureScheduler.kt
@@ -8,6 +8,7 @@ import com.ssak3.timeattack.task.domain.Task
 import com.ssak3.timeattack.task.domain.TaskStatus
 import com.ssak3.timeattack.task.domain.TaskStatus.Companion.statusesToFail
 import com.ssak3.timeattack.task.repository.TaskRepository
+import org.springframework.context.event.EventListener
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
@@ -19,6 +20,7 @@ class OverdueTaskFailureScheduler(
     private val taskScheduler: TaskScheduler,
     private val transactionTemplate: TransactionTemplate,
 ) : Logger {
+    @EventListener
     fun scheduleTaskTimeoutFailure(task: Task) {
         checkNotNull(task.id, "taskId")
 

--- a/src/main/kotlin/com/ssak3/timeattack/task/scheduler/OverdueTaskFailureScheduler.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/scheduler/OverdueTaskFailureScheduler.kt
@@ -6,6 +6,7 @@ import com.ssak3.timeattack.common.utils.Logger
 import com.ssak3.timeattack.common.utils.checkNotNull
 import com.ssak3.timeattack.task.domain.Task
 import com.ssak3.timeattack.task.domain.TaskStatus
+import com.ssak3.timeattack.task.domain.TaskStatus.Companion.statusesToFail
 import com.ssak3.timeattack.task.repository.TaskRepository
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.stereotype.Service
@@ -52,15 +53,5 @@ class OverdueTaskFailureScheduler(
                 logger.info("현재 상태가 ${beforeStatus}인 Task(${task.id})는 마감 시간이 지나 Fail 처리되었습니다.")
             }
         }
-    }
-
-    companion object {
-        val statusesToFail =
-            listOf(
-                TaskStatus.BEFORE,
-                TaskStatus.PROCRASTINATING,
-                TaskStatus.HOLDING_OFF,
-                TaskStatus.WARMING_UP,
-            )
     }
 }

--- a/src/main/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializer.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializer.kt
@@ -1,0 +1,36 @@
+package com.ssak3.timeattack.task.scheduler
+
+import com.ssak3.timeattack.common.utils.Logger
+import com.ssak3.timeattack.task.domain.Task
+import com.ssak3.timeattack.task.repository.TaskRepository
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class TaskSchedulerInitializer(
+    private val taskRepository: TaskRepository,
+    private val overdueTaskFailureScheduler: OverdueTaskFailureScheduler,
+) : Logger {
+    @EventListener(ApplicationReadyEvent::class)
+    fun initializeTaskSchedulers() {
+        logger.info("애플리케이션 시작 시 실패 처리 대상 작업 스케줄러 초기화 시작")
+
+        // 실패 처리 대상이 되는 작업들 조회
+        val tasksToSchedule =
+            taskRepository.findTasksToFail(
+                OverdueTaskFailureScheduler.statusesToFail,
+            )
+
+        logger.info("실패 처리 스케줄러에 등록할 작업 수: ${tasksToSchedule.size}")
+
+        // 각 작업에 대해 스케줄러 등록
+        tasksToSchedule.forEach { taskEntity ->
+            val task = Task.fromEntity(taskEntity)
+            logger.info("작업 스케줄러 등록: Task ID=${task.id}, 상태=${task.status}, 마감시간=${task.dueDatetime}")
+            overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(task)
+        }
+
+        logger.info("실패 처리 대상 작업 스케줄러 초기화 완료")
+    }
+}

--- a/src/main/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializer.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializer.kt
@@ -18,7 +18,7 @@ class TaskSchedulerInitializer(
 
         // 실패 처리 대상이 되는 작업들 조회
         val tasksToSchedule =
-            taskRepository.findTasksToFail(
+            taskRepository.findTodoTasks(
                 OverdueTaskFailureScheduler.statusesToFail,
             )
 

--- a/src/main/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializer.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializer.kt
@@ -11,11 +11,11 @@ import org.springframework.stereotype.Component
 @Component
 class TaskSchedulerInitializer(
     private val taskRepository: TaskRepository,
-    private val overdueTaskFailureScheduler: OverdueTaskFailureScheduler,
+    private val overdueTaskStatusUpdateScheduler: OverdueTaskStatusUpdateScheduler,
 ) : Logger {
     @EventListener(ApplicationReadyEvent::class)
     fun initializeTaskSchedulers() {
-        logger.info("애플리케이션 시작 시 실패 처리 대상 작업 스케줄러 초기화 시작")
+        logger.info("애플리케이션 시작 시 상태 수정 작업 스케줄러 초기화 시작")
 
         // 실패 처리 대상이 되는 작업들 조회
         val todoTaskEntities =
@@ -23,15 +23,15 @@ class TaskSchedulerInitializer(
                 statusesToFail,
             )
 
-        logger.info("실패 처리 스케줄러에 등록할 작업 수: ${todoTaskEntities.size}")
+        logger.info("상태 수정 처리 스케줄러에 등록할 작업 수: ${todoTaskEntities.size}")
 
         // 각 작업에 대해 스케줄러 등록
         todoTaskEntities.forEach { taskEntity ->
             val task = Task.fromEntity(taskEntity)
             logger.info("작업 스케줄러 등록: Task ID=${task.id}, 상태=${task.status}, 마감시간=${task.dueDatetime}")
-            overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(task)
+            overdueTaskStatusUpdateScheduler.scheduleTaskStatusUpdate(task)
         }
 
-        logger.info("실패 처리 대상 작업 스케줄러 초기화 완료")
+        logger.info("상태 수정 작업 스케줄러 초기화 완료")
     }
 }

--- a/src/main/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializer.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializer.kt
@@ -2,6 +2,7 @@ package com.ssak3.timeattack.task.scheduler
 
 import com.ssak3.timeattack.common.utils.Logger
 import com.ssak3.timeattack.task.domain.Task
+import com.ssak3.timeattack.task.domain.TaskStatus.Companion.statusesToFail
 import com.ssak3.timeattack.task.repository.TaskRepository
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
@@ -17,15 +18,15 @@ class TaskSchedulerInitializer(
         logger.info("애플리케이션 시작 시 실패 처리 대상 작업 스케줄러 초기화 시작")
 
         // 실패 처리 대상이 되는 작업들 조회
-        val tasksToSchedule =
+        val todoTaskEntities =
             taskRepository.findTodoTasks(
-                OverdueTaskFailureScheduler.statusesToFail,
+                statusesToFail,
             )
 
-        logger.info("실패 처리 스케줄러에 등록할 작업 수: ${tasksToSchedule.size}")
+        logger.info("실패 처리 스케줄러에 등록할 작업 수: ${todoTaskEntities.size}")
 
         // 각 작업에 대해 스케줄러 등록
-        tasksToSchedule.forEach { taskEntity ->
+        todoTaskEntities.forEach { taskEntity ->
             val task = Task.fromEntity(taskEntity)
             logger.info("작업 스케줄러 등록: Task ID=${task.id}, 상태=${task.status}, 마감시간=${task.dueDatetime}")
             overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(task)

--- a/src/main/kotlin/com/ssak3/timeattack/task/service/TaskService.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/service/TaskService.kt
@@ -62,8 +62,9 @@ class TaskService(
         // 3. Task 저장
         val savedTaskEntity = taskRepository.save(task.toEntity())
 
+        val savedTask = Task.fromEntity(savedTaskEntity)
         // 종료 시간에 실패 체크 스케줄러 등록
-        overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(task)
+        overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(savedTask)
 
         // 4. Task 반환
         return Task.fromEntity(savedTaskEntity)
@@ -106,7 +107,7 @@ class TaskService(
         val savedTask = Task.fromEntity(savedTaskEntity)
 
         // 종료 시간에 실패 체크 스케줄러 등록
-        overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(task)
+        overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(savedTask)
 
         // 5. Task 반환
         return savedTask

--- a/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
@@ -67,7 +67,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
 
         // 리포지토리 모킹 설정
         every {
-            taskRepository.findTasksToFail(OverdueTaskFailureScheduler.statusesToFail)
+            taskRepository.findTodoTasks(OverdueTaskFailureScheduler.statusesToFail)
         } returns listOf(taskEntity1, taskEntity2, taskEntity3)
 
         // 스케줄러 모킹 설정
@@ -81,7 +81,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
             Then("모든 대상 작업에 대해 스케줄러가 등록되어야 한다") {
                 // 메서드 호출 횟수 검증
                 verify(exactly = 1) {
-                    taskRepository.findTasksToFail(OverdueTaskFailureScheduler.statusesToFail)
+                    taskRepository.findTodoTasks(OverdueTaskFailureScheduler.statusesToFail)
                 }
 
                 // 각 작업에 대해 스케줄러 등록 검증
@@ -100,7 +100,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
 
         // 리포지토리 모킹 설정 - 빈 리스트 반환
         every {
-            taskRepository.findTasksToFail(OverdueTaskFailureScheduler.statusesToFail)
+            taskRepository.findTodoTasks(OverdueTaskFailureScheduler.statusesToFail)
         } returns emptyList()
 
         When("애플리케이션이 시작되면") {
@@ -109,7 +109,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
             Then("스케줄러 등록이 호출되지 않아야 한다") {
                 // 메서드 호출 검증
                 verify(exactly = 1) {
-                    taskRepository.findTasksToFail(OverdueTaskFailureScheduler.statusesToFail)
+                    taskRepository.findTodoTasks(OverdueTaskFailureScheduler.statusesToFail)
                 }
 
                 // 스케줄러 등록 호출 안 됨 검증

--- a/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
@@ -16,8 +16,8 @@ import java.time.LocalDateTime
 class TaskSchedulerInitializerTest : BehaviorSpec({
     // 테스트 대상 객체와 의존성
     val taskRepository = mockk<TaskRepository>()
-    val overdueTaskFailureScheduler = mockk<OverdueTaskFailureScheduler>()
-    val taskSchedulerInitializer = TaskSchedulerInitializer(taskRepository, overdueTaskFailureScheduler)
+    val overdueTaskStatusUpdateScheduler = mockk<OverdueTaskStatusUpdateScheduler>()
+    val taskSchedulerInitializer = TaskSchedulerInitializer(taskRepository, overdueTaskStatusUpdateScheduler)
 
     // 테스트 데이터 준비
     val now = LocalDateTime.now()
@@ -56,7 +56,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
 
     Given("실패 처리 대상이 되는 작업들이 있을 때") {
         // 이전 테스트의 모킹 초기화
-        clearMocks(overdueTaskFailureScheduler, taskRepository)
+        clearMocks(overdueTaskStatusUpdateScheduler, taskRepository)
 
         // 리포지토리 모킹 설정
         every {
@@ -65,7 +65,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
 
         // 스케줄러 모킹 설정
         every {
-            overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(any())
+            overdueTaskStatusUpdateScheduler.scheduleTaskStatusUpdate(any())
         } just Runs
 
         When("initializeTaskSchedulers가 호출되면") {
@@ -74,14 +74,14 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
             Then("모든 대상 작업에 대해 스케줄러가 등록되어야 한다") {
                 // 등록된 작업 수 검증
                 verify(exactly = 3) {
-                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(any())
+                    overdueTaskStatusUpdateScheduler.scheduleTaskStatusUpdate(any())
                 }
 
                 // ID로 작업 검증
                 verify {
-                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(match { it.id == 1L })
-                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(match { it.id == 2L })
-                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(match { it.id == 3L })
+                    overdueTaskStatusUpdateScheduler.scheduleTaskStatusUpdate(match { it.id == 1L })
+                    overdueTaskStatusUpdateScheduler.scheduleTaskStatusUpdate(match { it.id == 2L })
+                    overdueTaskStatusUpdateScheduler.scheduleTaskStatusUpdate(match { it.id == 3L })
                 }
             }
         }
@@ -89,7 +89,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
 
     Given("실패 처리 대상 작업이 없을 때") {
         // 이전 테스트의 모킹 초기화
-        clearMocks(overdueTaskFailureScheduler, taskRepository)
+        clearMocks(overdueTaskStatusUpdateScheduler, taskRepository)
 
         // 리포지토리 모킹 설정 - 빈 리스트 반환
         every {
@@ -102,7 +102,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
             Then("스케줄러 등록이 호출되지 않아야 한다") {
                 // 스케줄러 등록 호출 안 됨 검증
                 verify(exactly = 0) {
-                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(any())
+                    overdueTaskStatusUpdateScheduler.scheduleTaskStatusUpdate(any())
                 }
             }
         }

--- a/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
@@ -3,6 +3,7 @@ package com.ssak3.timeattack.task.scheduler
 import com.ssak3.timeattack.fixture.Fixture
 import com.ssak3.timeattack.task.domain.Task
 import com.ssak3.timeattack.task.domain.TaskStatus
+import com.ssak3.timeattack.task.domain.TaskStatus.Companion.statusesToFail
 import com.ssak3.timeattack.task.repository.TaskRepository
 import com.ssak3.timeattack.task.repository.entity.TaskEntity
 import io.kotest.core.spec.style.BehaviorSpec
@@ -67,7 +68,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
 
         // 리포지토리 모킹 설정
         every {
-            taskRepository.findTodoTasks(OverdueTaskFailureScheduler.statusesToFail)
+            taskRepository.findTodoTasks(statusesToFail)
         } returns listOf(taskEntity1, taskEntity2, taskEntity3)
 
         // 스케줄러 모킹 설정
@@ -81,7 +82,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
             Then("모든 대상 작업에 대해 스케줄러가 등록되어야 한다") {
                 // 메서드 호출 횟수 검증
                 verify(exactly = 1) {
-                    taskRepository.findTodoTasks(OverdueTaskFailureScheduler.statusesToFail)
+                    taskRepository.findTodoTasks(statusesToFail)
                 }
 
                 // 각 작업에 대해 스케줄러 등록 검증
@@ -100,7 +101,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
 
         // 리포지토리 모킹 설정 - 빈 리스트 반환
         every {
-            taskRepository.findTodoTasks(OverdueTaskFailureScheduler.statusesToFail)
+            taskRepository.findTodoTasks(statusesToFail)
         } returns emptyList()
 
         When("애플리케이션이 시작되면") {
@@ -109,7 +110,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
             Then("스케줄러 등록이 호출되지 않아야 한다") {
                 // 메서드 호출 검증
                 verify(exactly = 1) {
-                    taskRepository.findTodoTasks(OverdueTaskFailureScheduler.statusesToFail)
+                    taskRepository.findTodoTasks(statusesToFail)
                 }
 
                 // 스케줄러 등록 호출 안 됨 검증

--- a/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
@@ -1,0 +1,127 @@
+package com.ssak3.timeattack.task.scheduler
+
+import com.ssak3.timeattack.fixture.Fixture
+import com.ssak3.timeattack.task.domain.Task
+import com.ssak3.timeattack.task.domain.TaskStatus
+import com.ssak3.timeattack.task.repository.TaskRepository
+import com.ssak3.timeattack.task.repository.entity.TaskEntity
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import io.mockk.verify
+import java.time.LocalDateTime
+
+// @IntegrationTest
+class TaskSchedulerInitializerTest : BehaviorSpec({
+    // 테스트 대상 객체와 의존성
+    val taskRepository = mockk<TaskRepository>()
+    val overdueTaskFailureScheduler = mockk<OverdueTaskFailureScheduler>()
+    val taskSchedulerInitializer = TaskSchedulerInitializer(taskRepository, overdueTaskFailureScheduler)
+
+    // 테스트 데이터 준비
+    val now = LocalDateTime.now()
+    val tomorrow = now.plusDays(1)
+    val dayAfterTomorrow = now.plusDays(2)
+
+    // Fixture를 활용한 테스트 데이터 생성
+    val task1 =
+        Fixture.createScheduledTask(
+            id = 1L,
+            status = TaskStatus.BEFORE,
+            dueDatetime = tomorrow,
+        )
+
+    val task2 =
+        Fixture.createScheduledTask(
+            id = 2L,
+            status = TaskStatus.PROCRASTINATING,
+            dueDatetime = tomorrow,
+        )
+
+    val task3 =
+        Fixture.createScheduledTask(
+            id = 3L,
+            status = TaskStatus.HOLDING_OFF,
+            dueDatetime = dayAfterTomorrow,
+        )
+
+    // 테스트용 TaskEntity 모킹
+    val taskEntity1 = mockk<TaskEntity>()
+    val taskEntity2 = mockk<TaskEntity>()
+    val taskEntity3 = mockk<TaskEntity>()
+
+    // Task.fromEntity 모킹
+    mockkObject(Task.Companion)
+    every { Task.fromEntity(taskEntity1) } returns task1
+    every { Task.fromEntity(taskEntity2) } returns task2
+    every { Task.fromEntity(taskEntity3) } returns task3
+
+    Given("실패 처리 대상이 되는 작업들이 있을 때") {
+        // 이전 테스트의 모킹 초기화
+        clearMocks(overdueTaskFailureScheduler, taskRepository)
+
+        // 리포지토리 모킹 설정
+        every {
+            taskRepository.findTasksToFail(OverdueTaskFailureScheduler.statusesToFail)
+        } returns listOf(taskEntity1, taskEntity2, taskEntity3)
+
+        // 스케줄러 모킹 설정
+        every {
+            overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(any())
+        } just Runs
+
+        When("애플리케이션이 시작되면") {
+            taskSchedulerInitializer.initializeTaskSchedulers()
+
+            Then("모든 대상 작업에 대해 스케줄러가 등록되어야 한다") {
+                // 메서드 호출 횟수 검증
+                verify(exactly = 1) {
+                    taskRepository.findTasksToFail(OverdueTaskFailureScheduler.statusesToFail)
+                }
+
+                // 각 작업에 대해 스케줄러 등록 검증
+                verify(exactly = 1) {
+                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(task1)
+                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(task2)
+                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(task3)
+                }
+            }
+        }
+    }
+
+    Given("실패 처리 대상 작업이 없을 때") {
+        // 이전 테스트의 모킹 초기화
+        clearMocks(overdueTaskFailureScheduler, taskRepository)
+
+        // 리포지토리 모킹 설정 - 빈 리스트 반환
+        every {
+            taskRepository.findTasksToFail(OverdueTaskFailureScheduler.statusesToFail)
+        } returns emptyList()
+
+        When("애플리케이션이 시작되면") {
+            taskSchedulerInitializer.initializeTaskSchedulers()
+
+            Then("스케줄러 등록이 호출되지 않아야 한다") {
+                // 메서드 호출 검증
+                verify(exactly = 1) {
+                    taskRepository.findTasksToFail(OverdueTaskFailureScheduler.statusesToFail)
+                }
+
+                // 스케줄러 등록 호출 안 됨 검증
+                verify(exactly = 0) {
+                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(any())
+                }
+            }
+        }
+    }
+
+    // 테스트 종료 후 모킹 해제
+    afterSpec {
+        unmockkAll()
+    }
+})

--- a/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
@@ -1,23 +1,18 @@
 package com.ssak3.timeattack.task.scheduler
 
 import com.ssak3.timeattack.fixture.Fixture
-import com.ssak3.timeattack.task.domain.Task
 import com.ssak3.timeattack.task.domain.TaskStatus
 import com.ssak3.timeattack.task.domain.TaskStatus.Companion.statusesToFail
 import com.ssak3.timeattack.task.repository.TaskRepository
-import com.ssak3.timeattack.task.repository.entity.TaskEntity
 import io.kotest.core.spec.style.BehaviorSpec
 import io.mockk.Runs
 import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkObject
-import io.mockk.unmockkAll
 import io.mockk.verify
 import java.time.LocalDateTime
 
-// @IntegrationTest
 class TaskSchedulerInitializerTest : BehaviorSpec({
     // 테스트 대상 객체와 의존성
     val taskRepository = mockk<TaskRepository>()
@@ -51,16 +46,13 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
             dueDatetime = dayAfterTomorrow,
         )
 
-    // 테스트용 TaskEntity 모킹
-    val taskEntity1 = mockk<TaskEntity>()
-    val taskEntity2 = mockk<TaskEntity>()
-    val taskEntity3 = mockk<TaskEntity>()
-
-    // Task.fromEntity 모킹
-    mockkObject(Task.Companion)
-    every { Task.fromEntity(taskEntity1) } returns task1
-    every { Task.fromEntity(taskEntity2) } returns task2
-    every { Task.fromEntity(taskEntity3) } returns task3
+    // 테스트용 TaskEntity 생성
+    val taskEntities =
+        listOf(
+            task1.toEntity(),
+            task2.toEntity(),
+            task3.toEntity(),
+        )
 
     Given("실패 처리 대상이 되는 작업들이 있을 때") {
         // 이전 테스트의 모킹 초기화
@@ -69,7 +61,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
         // 리포지토리 모킹 설정
         every {
             taskRepository.findTodoTasks(statusesToFail)
-        } returns listOf(taskEntity1, taskEntity2, taskEntity3)
+        } returns taskEntities
 
         // 스케줄러 모킹 설정
         every {
@@ -80,16 +72,16 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
             taskSchedulerInitializer.initializeTaskSchedulers()
 
             Then("모든 대상 작업에 대해 스케줄러가 등록되어야 한다") {
-                // 메서드 호출 횟수 검증
-                verify(exactly = 1) {
-                    taskRepository.findTodoTasks(statusesToFail)
+                // 등록된 작업 수 검증
+                verify(exactly = 3) {
+                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(any())
                 }
 
-                // 각 작업에 대해 스케줄러 등록 검증
-                verify(exactly = 1) {
-                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(task1)
-                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(task2)
-                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(task3)
+                // ID로 작업 검증
+                verify {
+                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(match { it.id == 1L })
+                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(match { it.id == 2L })
+                    overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(match { it.id == 3L })
                 }
             }
         }
@@ -108,21 +100,11 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
             taskSchedulerInitializer.initializeTaskSchedulers()
 
             Then("스케줄러 등록이 호출되지 않아야 한다") {
-                // 메서드 호출 검증
-                verify(exactly = 1) {
-                    taskRepository.findTodoTasks(statusesToFail)
-                }
-
                 // 스케줄러 등록 호출 안 됨 검증
                 verify(exactly = 0) {
                     overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(any())
                 }
             }
         }
-    }
-
-    // 테스트 종료 후 모킹 해제
-    afterSpec {
-        unmockkAll()
     }
 })

--- a/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
@@ -104,7 +104,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
             taskRepository.findTodoTasks(statusesToFail)
         } returns emptyList()
 
-        When("애플리케이션이 시작되면") {
+        When("initializeTaskSchedulers가 호출되면") {
             taskSchedulerInitializer.initializeTaskSchedulers()
 
             Then("스케줄러 등록이 호출되지 않아야 한다") {

--- a/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/task/scheduler/TaskSchedulerInitializerTest.kt
@@ -76,7 +76,7 @@ class TaskSchedulerInitializerTest : BehaviorSpec({
             overdueTaskFailureScheduler.scheduleTaskTimeoutFailure(any())
         } just Runs
 
-        When("애플리케이션이 시작되면") {
+        When("initializeTaskSchedulers가 호출되면") {
             taskSchedulerInitializer.initializeTaskSchedulers()
 
             Then("모든 대상 작업에 대해 스케줄러가 등록되어야 한다") {


### PR DESCRIPTION
#111 

### Proposed Changes
- 작업 생성 시 `TaskScheduler`에 마감시간 + 1 분뒤에 실행되도록 등록

- 애플리케이션 시작 직후, DB에서 마감이 지나지 않았고, 현재 상태가 `BEFORE`, `PROCRASTINATING`, `HOLDING_OFF`, `WARMING_UP` 인 작업들 조회 후 `TaskScheduler`에 등록

- 등록된 시간이 되면, task를 DB에서 조회한 후, 현재 상태가 `BEFORE`, `PROCRASTINATING`, `HOLDING_OFF`, `WARMING_UP`라면 `FAIL`로 상태 수정 
- 등록된 시간이 되면, task를 DB에서 조회한 후, 현재 상태가 `FOCUSED` 라면 `COMPLETE`로 상태 수정

### Code Review Point
- 스케줄러 코드의 디렉토리 위치