### PR TITLE
feat: FCM 디바이스 등록 시 멤버-토큰 고유성 보장

### DIFF
--- a/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustom.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustom.kt
@@ -4,4 +4,9 @@ import com.ssak3.timeattack.notifications.repository.entity.FcmDeviceEntity
 
 interface FcmDeviceRepositoryCustom {
     fun findActiveByMember(memberId: Long): List<FcmDeviceEntity>
+
+    fun findActiveByMemberAndFcmToken(
+        memberId: Long,
+        fcmToken: String,
+    ): FcmDeviceEntity?
 }

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustomImpl.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/repository/FcmDeviceRepositoryCustomImpl.kt
@@ -18,4 +18,16 @@ class FcmDeviceRepositoryCustomImpl(
                 fcmDevice.status.isTrue,
             ).fetch()
     }
+
+    override fun findActiveByMemberAndFcmToken(
+        memberId: Long,
+        fcmToken: String,
+    ): FcmDeviceEntity? {
+        return queryFactory.selectFrom(fcmDevice)
+            .where(
+                fcmDevice.member.id.eq(memberId),
+                fcmDevice.fcmRegistrationToken.eq(fcmToken),
+                fcmDevice.status.isTrue,
+            ).fetchOne()
+    }
 }

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/repository/entity/FcmDeviceEntity.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/repository/entity/FcmDeviceEntity.kt
@@ -15,9 +15,18 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
 
 @Entity
-@Table(name = "fcm_devices")
+@Table(
+    name = "fcm_devices",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_member_token",
+            columnNames = ["member_id", "fcm_registration_token"],
+        ),
+    ],
+)
 class FcmDeviceEntity(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/service/FcmDeviceService.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/service/FcmDeviceService.kt
@@ -1,5 +1,6 @@
 package com.ssak3.timeattack.notifications.service
 
+import com.ssak3.timeattack.common.utils.checkNotNull
 import com.ssak3.timeattack.notifications.domain.FcmDevice
 import com.ssak3.timeattack.notifications.repository.FcmDeviceRepository
 import org.springframework.stereotype.Service
@@ -11,7 +12,15 @@ class FcmDeviceService(
 ) {
     @Transactional
     fun save(fcmDevice: FcmDevice) {
-        fcmDeviceRepository.save(fcmDevice.toEntity())
+        val memberId = checkNotNull(fcmDevice.member.id)
+
+        // 해당 유저의 기기가 이미 등록되어 있으면 등록하지 않음
+        fcmDeviceRepository.findActiveByMemberAndFcmToken(
+            memberId = memberId,
+            fcmToken = fcmDevice.fcmRegistrationToken,
+        )
+            ?.run { return }
+            ?: fcmDeviceRepository.save(fcmDevice.toEntity())
     }
 
     fun getDevicesByMember(memberId: Long): List<FcmDevice> =

--- a/src/test/kotlin/com/ssak3/timeattack/notifications/service/FcmDeviceServiceTest.kt
+++ b/src/test/kotlin/com/ssak3/timeattack/notifications/service/FcmDeviceServiceTest.kt
@@ -1,0 +1,79 @@
+package com.ssak3.timeattack.notifications.service
+
+import com.ssak3.timeattack.common.domain.DevicePlatform
+import com.ssak3.timeattack.fixture.Fixture
+import com.ssak3.timeattack.notifications.domain.FcmDevice
+import com.ssak3.timeattack.notifications.repository.FcmDeviceRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito.any
+import org.mockito.Mockito.never
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class FcmDeviceServiceTest {
+    @Mock
+    private lateinit var fcmDeviceRepository: FcmDeviceRepository
+
+    private lateinit var fcmDeviceService: FcmDeviceService
+
+    @BeforeEach
+    fun setup() {
+        fcmDeviceService = FcmDeviceService(fcmDeviceRepository)
+    }
+
+    @Test
+    @DisplayName("멤버와 FCM 토큰으로 등록된 디바이스가 없는 경우 새로운 디바이스를 저장한다")
+    fun saveWhenDeviceNotExists() {
+        // given
+        val member = Fixture.createMember(id = 1L)
+        val fcmToken = "test-fcm-token"
+        val fcmDevice =
+            FcmDevice(
+                member = member,
+                fcmRegistrationToken = fcmToken,
+                devicePlatform = DevicePlatform.IOS,
+                status = true,
+            )
+
+        `when`(fcmDeviceRepository.findActiveByMemberAndFcmToken(1L, fcmToken)).thenReturn(null)
+
+        // when
+        fcmDeviceService.save(fcmDevice)
+
+        // then
+        verify(fcmDeviceRepository, times(1)).findActiveByMemberAndFcmToken(1L, fcmToken)
+        verify(fcmDeviceRepository, times(1)).save(any())
+    }
+
+    @Test
+    @DisplayName("멤버와 FCM 토큰으로 등록된 디바이스가 이미 존재하는 경우 저장을 수행하지 않는다")
+    fun saveWhenDeviceExists() {
+        // given
+        val member = Fixture.createMember(id = 1L)
+        val fcmToken = "test-fcm-token"
+        val fcmDevice =
+            FcmDevice(
+                member = member,
+                fcmRegistrationToken = fcmToken,
+                devicePlatform = DevicePlatform.IOS,
+                status = true,
+            )
+
+        val fcmEntity = fcmDevice.toEntity()
+        `when`(fcmDeviceRepository.findActiveByMemberAndFcmToken(1L, fcmToken)).thenReturn(fcmEntity)
+
+        // when
+        fcmDeviceService.save(fcmDevice)
+
+        // then
+        verify(fcmDeviceRepository, times(1)).findActiveByMemberAndFcmToken(1L, fcmToken)
+        verify(fcmDeviceRepository, never()).save(any())
+    }
+}


### PR DESCRIPTION
### Proposed Changes
- FCM 디바이스 엔티티에 member_id와 fcm_registration_token 조합의 UK 제약 조건 추가
- 디바이스 등록 전 중복 체크 로직 구현
- 동일 사용자의 다양한 디바이스 지원하면서 중복 등록 방지
- 테스트 코드 추가
 
### Code Review Point
(리뷰어가 중점적으로 보면 좋을 부분을 적어주세요.)
