### PR TITLE
task id nullable 로 변경

### DIFF
--- a/src/main/kotlin/com/ssak3/timeattack/external/firebase/FirebaseCloudMessageService.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/external/firebase/FirebaseCloudMessageService.kt
@@ -18,6 +18,10 @@ class FirebaseCloudMessageService : Logger {
         logger.info("[Firebase Messaging] start to send: $message")
         val firebaseMessaging = FirebaseMessaging.getInstance()
 
+        val data = mutableMapOf<String, String>()
+        data["route"] = message.route
+        message.taskId?.let { data["taskId"] = message.taskId.toString() }
+
         val fcmMessage =
             Message.builder()
                 .setToken(message.token)
@@ -26,12 +30,7 @@ class FirebaseCloudMessageService : Logger {
                 )
                 .setApnsConfig(getAPNSConfig())
                 .setAndroidConfig(getAndroidConfig())
-                .putAllData(
-                    mapOf(
-                        "route" to message.route,
-                        "taskId" to message.taskId.toString(),
-                    ),
-                )
+                .putAllData(data)
                 .build()
 
         var response = ""

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmMessage.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmMessage.kt
@@ -5,7 +5,7 @@ import com.ssak3.timeattack.external.firebase.domain.DevicePlatform
 data class FcmMessage(
     val token: String,
     val platform: DevicePlatform,
-    val taskId: Long,
+    val taskId: Long? = null,
     val body: String,
     val route: String,
     val title: String = "SPURT",

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmNotificationConstants.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/domain/FcmNotificationConstants.kt
@@ -31,7 +31,7 @@ object FcmNotificationConstants {
     fun getRoute(order: Int): String {
         // 0보다 작을 경우 = 응원 문구 푸시 알림
         return if (order < 0) {
-            "/home-page"
+            "/"
         } else if (order == 0) {
             "/action/start"
         } else {

--- a/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationScheduler.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/notifications/service/PushNotificationScheduler.kt
@@ -25,11 +25,13 @@ class PushNotificationScheduler(
             checkNotNull(it.member.id)
             checkNotNull(it.task.id)
             fcmDeviceService.getDevicesByMember(it.member.id).forEach { device ->
+                // 응원문구(홈으로 가는 푸시 알림)은 task id 전달되면 안됨
+                val taskId = if (it.order < 0) null else it.task.id
                 val message =
                     FcmMessage(
                         token = device.fcmRegistrationToken,
                         platform = DevicePlatform.valueOf(device.devicePlatform.toString()),
-                        taskId = it.task.id,
+                        taskId = taskId,
                         body = it.message,
                         route = getRoute(it.order),
                         title = it.task.name,

--- a/src/main/kotlin/com/ssak3/timeattack/task/controller/TaskController.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/controller/TaskController.kt
@@ -72,7 +72,7 @@ class TaskController(
         checkNotNull(member.id) { throw ApplicationException(UNAUTHORIZED_ACCESS) }
         val changedStatusTask = taskService.changeTaskStatus(taskId, member.id, taskStatusRequest.status)
 
-        logger.info("======== 변경된 작업 확인: $changedStatusTask")
+        logger.info("======== 변경 요청한 작업 상태[${taskStatusRequest.status}] -> 변경된 작업 상태[${changedStatusTask.status}]")
 
         // 몰입 상태가 되면 응원 문구 푸시 알림 요청
         if (changedStatusTask.status == TaskStatus.FOCUSED) {

--- a/src/main/kotlin/com/ssak3/timeattack/task/controller/TaskController.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/controller/TaskController.kt
@@ -41,7 +41,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/v1/tasks")
 class TaskController(
     private val taskService: TaskService,
-): Logger {
+) : Logger {
     @Operation(summary = "긴급 업무 생성", security = [SecurityRequirement(name = SECURITY_SCHEME_NAME)])
     @PostMapping("/urgent")
     fun createUrgentTask(

--- a/src/main/kotlin/com/ssak3/timeattack/task/controller/TaskController.kt
+++ b/src/main/kotlin/com/ssak3/timeattack/task/controller/TaskController.kt
@@ -4,6 +4,7 @@ import com.ssak3.timeattack.common.config.SwaggerConfig.Companion.SECURITY_SCHEM
 import com.ssak3.timeattack.common.dto.MessageResponse
 import com.ssak3.timeattack.common.exception.ApplicationException
 import com.ssak3.timeattack.common.exception.ApplicationExceptionType.UNAUTHORIZED_ACCESS
+import com.ssak3.timeattack.common.utils.Logger
 import com.ssak3.timeattack.member.domain.Member
 import com.ssak3.timeattack.task.controller.dto.HomeTasksResponse
 import com.ssak3.timeattack.task.controller.dto.ScheduledTaskCreateRequest
@@ -40,7 +41,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/v1/tasks")
 class TaskController(
     private val taskService: TaskService,
-) {
+): Logger {
     @Operation(summary = "긴급 업무 생성", security = [SecurityRequirement(name = SECURITY_SCHEME_NAME)])
     @PostMapping("/urgent")
     fun createUrgentTask(
@@ -70,6 +71,8 @@ class TaskController(
     ): ResponseEntity<TaskStatusResponse> {
         checkNotNull(member.id) { throw ApplicationException(UNAUTHORIZED_ACCESS) }
         val changedStatusTask = taskService.changeTaskStatus(taskId, member.id, taskStatusRequest.status)
+
+        logger.info("======== 변경된 작업 확인: $changedStatusTask")
 
         // 몰입 상태가 되면 응원 문구 푸시 알림 요청
         if (changedStatusTask.status == TaskStatus.FOCUSED) {


### PR DESCRIPTION
(# 입력 하고 이슈 선택)

### Proposed Changes
* route 가 홈으로 가는 경우("/") = 응원문구 푸시 알림 발송하는 경우 taskId가 response에 포함되면 안됨 (프론트 코드 수정 불가로 서버에서 제어) -> task id nullable 로 수정
* 응원문구 푸시 알림 제대로 설정 안되는 것 같아서 확인을 위해 작업 상태 변경 로그 추가

### Code Review Point
(리뷰어가 중점적으로 보면 좋을 부분을 적어주세요.)
